### PR TITLE
Refactored all classes in `maps` package to use constructors with `Class`

### DIFF
--- a/didelphis-common-language/src/main/java/org/didelphis/language/automata/parsing/RegexParser.java
+++ b/didelphis-common-language/src/main/java/org/didelphis/language/automata/parsing/RegexParser.java
@@ -82,6 +82,7 @@ public final class RegexParser implements LanguageParser<String> {
 	private static final Map<String, String> ESCAPES   = new LinkedHashMap<>();
 
 	private static final Set<String> QUANTIFIERS = new HashSet<>();
+	private static final MultiMap<String, String> EMPTY_SPECIALS = new GeneralMultiMap<>();
 
 	static {
 		DELIM.put("[", "]");
@@ -239,7 +240,7 @@ public final class RegexParser implements LanguageParser<String> {
 	@NonNull
 	@Override
 	public MultiMap<String, String> getSpecialsMap() {
-		return GeneralMultiMap.emptyMultiMap();
+		return EMPTY_SPECIALS;
 	}
 
 	@NonNull

--- a/didelphis-common-language/src/main/java/org/didelphis/language/automata/statemachines/StandardStateMachine.java
+++ b/didelphis-common-language/src/main/java/org/didelphis/language/automata/statemachines/StandardStateMachine.java
@@ -227,7 +227,7 @@ public final class StandardStateMachine<S> implements StateMachine<S> {
 				// This check is done because not all nodes are keys in the
 				// graph; if a node is terminal, with no outgoing arcs, then
 				// the node will not be a key in the graph
-				if (graph.containsKey(currentNode)) {
+				if (graph.containsFirstKey(currentNode)) {
 					if (cursor.getIndex() > parser.lengthOf(input)) {
 						continue;
 					}

--- a/didelphis-common-language/src/main/java/org/didelphis/language/phonetic/model/FeatureModelLoader.java
+++ b/didelphis-common-language/src/main/java/org/didelphis/language/phonetic/model/FeatureModelLoader.java
@@ -32,7 +32,6 @@ import org.didelphis.language.parsing.ParseException;
 import org.didelphis.language.phonetic.features.FeatureArray;
 import org.didelphis.language.phonetic.features.FeatureType;
 import org.didelphis.language.phonetic.features.SparseFeatureArray;
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.GeneralMultiMap;
 import org.didelphis.structures.maps.interfaces.MultiMap;
 import org.didelphis.utilities.Logger;
@@ -42,9 +41,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -125,11 +122,10 @@ public final class FeatureModelLoader<T> {
 		featureIndices = new HashMap<>();
 		basePath = path;
 
-		Map<ParseZone, Collection<String>> map = new EnumMap<>(ParseZone.class);
+		zoneData = new GeneralMultiMap<>(HashMap.class, ArrayList.class);
 		for (ParseZone zone : ParseZone.values()) {
-			map.put(zone, new ArrayList<>());
+			zoneData.put(zone, new ArrayList<>());
 		}
-		zoneData = new GeneralMultiMap<>(map, Suppliers.ofList());
 
 		try {
 			String read = fileHandler.read(path);
@@ -154,11 +150,10 @@ public final class FeatureModelLoader<T> {
 		featureNames = new ArrayList<>();
 		featureIndices = new HashMap<>();
 
-		Map<ParseZone, Collection<String>> map = new EnumMap<>(ParseZone.class);
+		zoneData = new GeneralMultiMap<>(HashMap.class, ArrayList.class);
 		for (ParseZone zone : ParseZone.values()) {
-			map.put(zone, new ArrayList<>());
+			zoneData.put(zone, new ArrayList<>());
 		}
-		zoneData = new GeneralMultiMap<>(map, Suppliers.ofList());
 
 		parse(lines);
 		populate();

--- a/didelphis-common-language/src/test/java/org/didelphis/language/automata/StandardStateMachineStringTest.java
+++ b/didelphis-common-language/src/test/java/org/didelphis/language/automata/StandardStateMachineStringTest.java
@@ -26,7 +26,6 @@ import org.didelphis.language.automata.parsing.StringParser;
 import org.didelphis.language.automata.statemachines.StandardStateMachine;
 import org.didelphis.language.automata.statemachines.StateMachine;
 import org.didelphis.language.parsing.ParseException;
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.GeneralMultiMap;
 import org.didelphis.structures.maps.interfaces.MultiMap;
 
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -1051,7 +1051,7 @@ class StandardStateMachineStringTest extends StateMachineTestBase<String> {
 		List<String> strings = Arrays.asList(split[1].split("\\s+"));
 		Map<String, Collection<String>> map = new HashMap<>();
 		map.put(split[0], strings);
-		return new GeneralMultiMap<>(map, Suppliers.ofHashSet());
+		return new GeneralMultiMap<>(HashMap.class, HashSet.class, map);
 	}
 
 	private static StateMachine<String> getMachine(String expression) {

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/Structure.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/Structure.java
@@ -48,10 +48,6 @@ public interface Structure {
 
 	/**
 	 * Deletes all contents from the structure.
-	 *
-	 * @return true iff contents were deleted; if the structure was already
-	 *      empty, this operation will return false.
 	 */
-	@SuppressWarnings ("BooleanMethodNameMustStartWithQuestion")
-	boolean clear();
+	void clear();
 }

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/Suppliers.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/Suppliers.java
@@ -19,10 +19,14 @@
 
 package org.didelphis.structures;
 
+import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.UtilityClass;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -66,5 +70,89 @@ public final class Suppliers {
 
 	public <K, V> Supplier<NavigableMap<K, V>> ofTreeMap() {
 		return TreeMap::new;
+	}
+
+	public <K, V> Supplier<Map<K, V>> mapOf(
+			@NonNull Class<? extends Map<?, ?>> type
+	) {
+		return new MapSupplier<>(type);
+	}
+
+	public <E> Supplier<Collection<E>> collectionOf(
+			@NonNull Class<? extends Collection<?>> type
+	) {
+		return new CollectionSupplier<>(type);
+	}
+
+	private static final class CollectionSupplier<E>
+			implements Supplier<Collection<E>> {
+
+		private final Class<? extends Collection<?>> type;
+
+		private CollectionSupplier(Class<? extends Collection<?>> type) {
+			this.type = type;
+		}
+
+		@Override
+		@SuppressWarnings ("unchecked")
+		public Collection<E> get() {
+			try {
+				Constructor<? extends Collection<?>> constructor =
+						type.getConstructor();
+				return (Collection<E>) constructor.newInstance();
+			} catch (NoSuchMethodException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it does not have " +
+						"a default constructor.", e);
+			} catch (IllegalAccessException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it does not have " +
+						"access to the class definition.", e);
+			} catch (InstantiationException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it cannot be " +
+						"instantiated.", e);
+			} catch (InvocationTargetException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; an error occurred " +
+						"while instantiating it.", e);
+			}
+		}
+	}
+
+	private static final class MapSupplier<K, V>
+			implements Supplier<Map<K, V>> {
+
+		private final Class<? extends Map<?, ?>> type;
+
+		private MapSupplier(Class<? extends Map<?, ?>> type) {
+			this.type = type;
+		}
+
+		@Override
+		@SuppressWarnings ("unchecked")
+		public Map<K, V> get() {
+			try {
+				Constructor<? super Map<?, ?>> constructor =
+						(Constructor<? super Map<?, ?>>) type.getConstructor();
+				return (Map<K, V>) constructor.newInstance();
+			} catch (NoSuchMethodException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it does not have " +
+						"a default constructor.", e);
+			} catch (IllegalAccessException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it does not have " +
+						"access to the class definition.", e);
+			} catch (InstantiationException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; it cannot be " +
+						"instantiated.", e);
+			} catch (InvocationTargetException e) {
+				throw new IllegalArgumentException("Unable to create new two " +
+						"key map using the provided class; an error occurred " +
+						"while instantiating it.", e);
+			}
+		}
 	}
 }

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/graph/Graph.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/graph/Graph.java
@@ -23,10 +23,13 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.GeneralTwoKeyMultiMap;
+import org.didelphis.structures.maps.interfaces.TwoKeyMap;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Class {@code Graph}
@@ -37,20 +40,18 @@ public final class Graph<S>
 		extends GeneralTwoKeyMultiMap<String, Arc<S>, String> {
 
 	public Graph() {
-		super(new HashMap<>(), Suppliers.ofLinkedHashMap(), Suppliers.ofList());
+		super(LinkedHashMap.class, ArrayList.class);
 	}
 
-	public Graph(@NonNull GeneralTwoKeyMultiMap<String, Arc<S>, String> graph) {
-		super(
-				graph,
-				new HashMap<>(),
-				Suppliers.ofLinkedHashMap(),
-				Suppliers.ofList()
-		);
+	public Graph(@NonNull TwoKeyMap<String, Arc<S>, Collection<String>> graph) {
+		super(LinkedHashMap.class, ArrayList.class, graph);
+	}
+
+	public Map<Arc<S>, Collection<String>> get(String key) {
+		return getDelegate().get(key);
 	}
 
 	public static class EmptyArc<S> implements Arc<S> {
-
 		@Override
 		public String toString() {
 			return "";

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/maps/SymmetricalTwoKeyMap.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/maps/SymmetricalTwoKeyMap.java
@@ -29,12 +29,8 @@ import org.didelphis.structures.tuples.Tuple;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 
 @ToString(callSuper = true)
@@ -45,38 +41,32 @@ public class SymmetricalTwoKeyMap<K, V> extends GeneralTwoKeyMap<K, K, V>
 	/**
 	 * Default constructor which uses a {@link HashMap} delegate
 	 */
-	public SymmetricalTwoKeyMap() {
+	public SymmetricalTwoKeyMap() {}
+
+	/**
+	 * Standard constructor, allows the user to specify which type of {@link
+	 * Map} the two-key-map should use
+	 *
+	 * @param mapType the type of map used to construct the two-key-map
+	 */
+	@SuppressWarnings ("rawtypes")
+	public SymmetricalTwoKeyMap(Class<? extends Map> mapType) {
+		super(mapType);
 	}
 
 	/**
-	 * Standard non-copying constructor which uses the provided delegate map and
-	 * creates new entries using the provided supplier.
+	 * Copy constructor, allows the user to specify which type of {@link Map}
+	 * the two-key-map should use, and what data to copy into this instance
 	 *
-	 * @param delegate a delegate map to be used by the new multimap
-	 * @param mapSupplier a {@link Supplier} to provide the inner map
-	 *      instances
+	 * @param mapType the type of map used to construct the two-key-map
+	 * @param iterable the data to copy into the new instance
 	 */
+	@SuppressWarnings ("rawtypes")
 	public SymmetricalTwoKeyMap(
-			@NonNull Map<K, Map<K, V>> delegate,
-			@NonNull Supplier<? extends Map<K, V>> mapSupplier
+			@NonNull Class<? extends Map> mapType,
+			@NonNull Iterable<Triple<K, K, V>> iterable
 	) {
-		super(delegate, mapSupplier);
-	}
-
-	/**
-	 * Copy-constructor; creates a deep copy of the provided multi-map using
-	 * the provided suppliers
-	 *
-	 * @param tripleIterable triples whose data is to be copied
-	 * @param delegate a (typically empty) delegate map
-	 * @param mapSupplier a {@link Supplier} to provide the inner map
-	 */
-	public SymmetricalTwoKeyMap(
-			@NonNull Iterable<Triple<K, K, V>> tripleIterable,
-			@NonNull Map<K, Map<K, V>> delegate,
-			@NonNull Supplier<? extends Map<K, V>> mapSupplier
-	) {
-		super(tripleIterable, delegate, mapSupplier);
+		super(mapType, iterable);
 	}
 
 	@Override
@@ -95,16 +85,5 @@ public class SymmetricalTwoKeyMap<K, V> extends GeneralTwoKeyMap<K, K, V>
 	public boolean contains(@Nullable K k1, @Nullable K k2) {
 		Tuple<K, K> tuple = canonicalKeyPair(k1, k2);
 		return super.contains(tuple.getLeft(), tuple.getRight());
-	}
-
-	@NonNull
-	@Override
-	public Collection<K> getAssociatedKeys(@Nullable K k1) {
-		return keys().stream()
-				.filter(tuple -> tuple.contains(k1))
-				.map(tuple -> Objects.equals(tuple.getLeft(), k1)
-						? tuple.getRight()
-						: tuple.getLeft())
-				.collect(Collectors.toSet());
 	}
 }

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/maps/interfaces/TwoKeyMap.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/maps/interfaces/TwoKeyMap.java
@@ -21,6 +21,7 @@ package org.didelphis.structures.maps.interfaces;
 
 import lombok.NonNull;
 
+import org.didelphis.structures.Structure;
 import org.didelphis.structures.contracts.Streamable;
 import org.didelphis.structures.tuples.Triple;
 import org.didelphis.structures.tuples.Tuple;
@@ -28,7 +29,6 @@ import org.didelphis.structures.tuples.Tuple;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -36,8 +36,8 @@ import java.util.Map;
  *
  * @since 0.1.0
  */
-public interface TwoKeyMap<T, U, V>
-		extends Map<T, Map<U, V>>, Streamable<Triple<T, U, V>> {
+public interface TwoKeyMap<T, U, V> extends Streamable<Triple<T, U, V>>,
+		Structure {
 
 	/**
 	 * Return the value stored under the two keys
@@ -71,6 +71,36 @@ public interface TwoKeyMap<T, U, V>
 	boolean contains(@Nullable T k1, @Nullable U k2);
 
 	/**
+	 * Checks whether a key is present as part of a key-pair in the first
+	 * position
+	 *
+	 * @param k1 the first key; may be {@code null}
+	 *
+	 * @return true if a key is present as part of a key-pair
+	 */
+	boolean containsFirstKey(@Nullable T k1);
+
+	/**
+	 * Checks whether a key is present as part of a key-pair in the second
+	 * position
+	 *
+	 * @param k2 the first key; may be {@code null}
+	 *
+	 * @return true if a key is present as part of a key-pair
+	 */
+	boolean containsSecondKey(@Nullable U k2);
+
+	/**
+	 * Returns {@code true} if any keys map to the provided value.
+	 *
+	 * @param value value whose presence in this map is to be tested
+	 *
+	 * @return {@code true} if this map maps one or more keys to the
+	 *      specified value
+	 */
+	boolean containsValue(@Nullable V value);
+
+	/**
 	 * Updates the stored value using the one provided; by default this is the
 	 * same as calling {@link TwoKeyMap#put(T, U, V)} but implementations may
 	 * override this to support behavior like adding numbers, appending strings,
@@ -91,22 +121,13 @@ public interface TwoKeyMap<T, U, V>
 	@NonNull Collection<Tuple<T, U>> keys();
 
 	/**
-	 * Returns the number of key-value mappings in this map.  If the map
-	 * contains more than {@code Integer.MAX_VALUE} elements, returns {@code
+	 * Returns the number of key pairs in this map.  If the map contains more
+	 * than {@code Integer.MAX_VALUE} key pairs, this returns {@code
 	 * Integer.MAX_VALUE}.
 	 *
-	 * @return the number of key-value mappings in this map
-	 *
-	 * @implNote for complex map structures, it is not necessarily apparent
-	 *      what semantics of {@code size()} should be. However, one reasonable and
-	 *      consistent solution is that {@code size()} out to return the same
-	 *      number of items as are contained within the output of {@code
-	 *      iterator()}
+	 * @return the number of key pairs in this map
 	 */
-	@Override
-	default int size() {
-		return Math.toIntExact(stream().count());
-	}
+	int size();
 
 	/**
 	 * Remove and return the value stored under the two keys
@@ -118,13 +139,8 @@ public interface TwoKeyMap<T, U, V>
 	 *      either the keys have no associated value or if a {@code null} has
 	 *      been stored explicitly
 	 */
-	default @Nullable V removeKeys(@Nullable T k1, @Nullable U k2) {
-		if (contains(k1, k2)) {
-			Map<U, V> map = get(k1);
-			return map.remove(k2);
-		}
-		return null;
-	}
+	@Nullable
+	V removeKeys(@Nullable T k1, @Nullable U k2);
 
 	/**
 	 * A null-safe version of {@link #contains(T, U)}
@@ -137,20 +153,6 @@ public interface TwoKeyMap<T, U, V>
 	 */
 	default boolean containsNotNull(@Nullable T k1, @Nullable U k2) {
 		return contains(k1, k2) && get(k1, k2) != null;
-	}
-
-	/**
-	 * Returns all keys associated with the provided key such that, together,
-	 * they have an associated value
-	 *
-	 * @param k1 the first key; may be null
-	 *
-	 * @return a collection of the second keys associated with the provided key;
-	 *      null if the provided key is not present
-	 */
-	@NonNull
-	default Collection<U> getAssociatedKeys(@Nullable T k1) {
-		return containsKey(k1) ? get(k1).keySet() : Collections.emptySet();
 	}
 
 	/**
@@ -170,11 +172,25 @@ public interface TwoKeyMap<T, U, V>
 	default V getOrDefault(@Nullable T k1, @Nullable U k2, @NonNull V value) {
 		if (contains(k1, k2)) {
 			V v = get(k1, k2);
-			if (v == null) {
-				return value;
-			}
-			return v;
+			return v == null ? value : v;
 		}
 		return value;
 	}
+
+	/**
+	 * Copies all of the mappings from the specified map to this map
+	 * (optional operation).  The effect of this call is equivalent to that
+	 * of calling {@link #put(T, U, V)} on this map once for each mapping from
+	 * each key pair to value in the map.
+	 *
+	 * @param map mappings to be stored in this map; not {@code null}
+	 *
+	 * @throws UnsupportedOperationException if the {@code putAll} operation
+	 * 		is not supported by this map
+	 * @throws ClassCastException if the class of a key or value in the
+	 * 		specified map prevents it from being stored in this map
+	 * @throws IllegalArgumentException if some property of a key or value in
+	 * 		the specified map prevents it from being stored in this map
+	 */
+	void putAll(@NonNull TwoKeyMap<T, U, V> map);
 }

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/AbstractTable.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/AbstractTable.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 
 import org.didelphis.utilities.Templates;
 
-import java.text.DecimalFormat;
 import java.util.Collection;
 
 /**
@@ -36,9 +35,6 @@ import java.util.Collection;
 @ToString
 @EqualsAndHashCode
 public abstract class AbstractTable<E> implements ResizeableTable<E> {
-
-	@Deprecated protected static final DecimalFormat DECIMAL_FORMAT
-			= new DecimalFormat(" 0.000;-0.000");
 
 	private int rows;
 	private int columns;

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/RectangularTable.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/RectangularTable.java
@@ -198,12 +198,10 @@ public class RectangularTable<E> extends AbstractTable<E> {
 	}
 
 	@Override
-	public boolean clear() {
-		boolean clear = !isEmpty();
+	public void clear() {
 		array.clear();
 		setRows(0);
 		setColumns(0);
-		return clear;
 	}
 
 	@Override

--- a/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/SymmetricTable.java
+++ b/didelphis-common-structures/src/main/java/org/didelphis/structures/tables/SymmetricTable.java
@@ -189,12 +189,10 @@ public class SymmetricTable<E> extends AbstractTable<E> {
 	}
 
 	@Override
-	public boolean clear() {
-		boolean contentsRemoved = !isEmpty();
+	public void clear() {
 		array.clear();
 		setRows(0);
 		setColumns(0);
-		return contentsRemoved;
 	}
 
 	@Override

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralMultiMapTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralMultiMapTest.java
@@ -19,7 +19,7 @@
 
 package org.didelphis.structures.maps;
 
-import org.didelphis.structures.Suppliers;
+import org.didelphis.structures.maps.interfaces.MultiMap;
 import org.didelphis.structures.tuples.Tuple;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,16 +31,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 
+@SuppressWarnings ("rawtypes")
 class GeneralMultiMapTest {
 
-	private GeneralMultiMap<String, String> map;
-	private GeneralMultiMap<String, String> map1;
+	private static final Class<HashMap> MAP_TYPE = HashMap.class;
+	private static final Class<HashSet> SET_TYPE = HashSet.class;
+
+	MultiMap<String, String> map;
+	MultiMap<String, String> map1;
 
 	@BeforeEach
 	void init() {
@@ -52,11 +55,7 @@ class GeneralMultiMapTest {
 		map.add("Z", "e");
 		map.add("Z", "f");
 
-		map1 = new GeneralMultiMap<>(
-				map,
-				new HashMap<>(),
-				Suppliers.ofHashSet()
-		);
+		map1 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE, map);
 		map1.add("X", "1");
 		map1.add("X", "2");
 	}
@@ -123,18 +122,7 @@ class GeneralMultiMapTest {
 	@Test
 	void addAll() {
 		map.addAll("X", Arrays.asList("1", "2", "3"));
-		assertEquals(new HashSet<>(Arrays.asList("a", "1", "2", "3")),
-				map.get("X")
-		);
-	}
-
-	@Test
-	void getDelegate() {
-		Map<String, Collection<String>> delegate = new HashMap<>();
-		delegate.put("X", new HashSet<>(Collections.singletonList("a")));
-		delegate.put("Y", new HashSet<>(Arrays.asList("b", "c")));
-		delegate.put("Z", new HashSet<>(Arrays.asList("d", "e", "f")));
-		assertEquals(delegate, map.getDelegate());
+		assertEquals(new HashSet<>(Arrays.asList("a", "1", "2", "3")), map.get("X"));
 	}
 
 	@Test
@@ -145,7 +133,7 @@ class GeneralMultiMapTest {
 	@Test
 	void isEmpty() {
 		assertFalse(map.isEmpty());
-		assertTrue(new GeneralMultiMap<>().isEmpty());
+		assertTrue(new GeneralMultiMap<>(MAP_TYPE, SET_TYPE).isEmpty());
 	}
 
 	@Test
@@ -163,40 +151,29 @@ class GeneralMultiMapTest {
 
 	@Test
 	void equals() {
-		assertEquals(
-				map,
-				new GeneralMultiMap<>(map,
-						new HashMap<>(),
-						Suppliers.ofHashSet()
-				)
-		);
+		MultiMap<?, ?> m1 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE, map);
+		assertEquals(map, m1);
 		assertNotEquals(map, new GeneralMultiMap<>());
 		assertNotEquals(map, map1);
 	}
 
 	@Test
 	void testHashCode() {
-		assertEquals(
-				map.hashCode(),
-				new GeneralMultiMap<>(map,
-						new HashMap<>(),
-						Suppliers.ofHashSet()
-				).hashCode()
-		);
-		assertNotEquals(map.hashCode(), new GeneralMultiMap<>().hashCode());
+		MultiMap<?, ?> m1 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE, map);
+		MultiMap<?, ?> m2 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE);
+
+		assertEquals(map.hashCode(), m1.hashCode());
+		assertNotEquals(map.hashCode(), m2.hashCode());
 		assertNotEquals(map.hashCode(), map1.hashCode());
 	}
 
 	@Test
 	void testToString() {
-		assertEquals(
-				map.toString(),
-				new GeneralMultiMap<>(map,
-						new HashMap<>(),
-						Suppliers.ofHashSet()
-				).toString()
-		);
-		assertNotEquals(map.toString(), new GeneralMultiMap<>().toString());
+		MultiMap<?, ?> m1 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE, map);
+		MultiMap<?, ?> m2 = new GeneralMultiMap<>(MAP_TYPE, SET_TYPE);
+
+		assertEquals(map.toString(), m1.toString());
+		assertNotEquals(map.toString(), m2.toString());
 		assertNotEquals(map.toString(), map1.toString());
 	}
 

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralTwoKeyMapTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralTwoKeyMapTest.java
@@ -19,7 +19,6 @@
 
 package org.didelphis.structures.maps;
 
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.interfaces.TwoKeyMap;
 import org.didelphis.structures.tuples.Couple;
 import org.didelphis.structures.tuples.Triple;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -37,12 +35,18 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 
+class GeneralTwoKeyMapTest extends TwoKeyMapTestBase<String, String, String> {
 
-class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
+	@Test
+	void testByClassConstructor() {
+		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
+		map.put("A", "A", "A");
+		assertEquals("A", map.get("A", "A"));
+	}
 
 	@Test
 	void iterator() {
-		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
@@ -62,7 +66,7 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 
 	@Test
 	void testPutAndGet() {
-		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a", "b", "c");
 
 		testGet(map, "a", "b", "c");
@@ -72,7 +76,7 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 
 	@Test
 	void testContains() {
-		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
@@ -88,12 +92,12 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 
 	@Test
 	void testKeys() {
-		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
 
-		Collection<Tuple<String,String>> expected = new ArrayList<>();
+		Collection<Tuple<String, String>> expected = new ArrayList<>();
 		expected.add(new Couple<>("a1", "b1"));
 		expected.add(new Couple<>("a2", "b2"));
 		expected.add(new Couple<>("a3", "b3"));
@@ -102,26 +106,8 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 	}
 
 	@Test
-	void testAssociatedKeys() {
-		TwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
-		map.put("A", "1a", "v1a");
-
-		map.put("B", "2a", "v2a");
-		map.put("B", "2b", "v2b");
-
-		map.put("C", "3a", "v3a");
-		map.put("C", "3b", "v3b");
-		map.put("C", "3c", "v3c");
-
-		assertEquals(1,map.getAssociatedKeys("A").size());
-		assertEquals(2,map.getAssociatedKeys("B").size());
-		assertEquals(3,map.getAssociatedKeys("C").size());
-		assertEquals(Collections.emptySet(), map.getAssociatedKeys("X"));
-	}
-
-	@Test
 	void testEquals() {
-		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
@@ -136,7 +122,7 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 
 	@Test
 	void testToString() {
-		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
@@ -151,7 +137,7 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 
 	@Test
 	void testHashCode() {
-		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>();
+		GeneralTwoKeyMap<String, String, String> map = new GeneralTwoKeyMap<>(HashMap.class);
 		map.put("a1", "b1", "v1");
 		map.put("a2", "b2", "v2");
 		map.put("a3", "b3", "v3");
@@ -165,7 +151,8 @@ class GeneralTwoKeyMapTest extends TwoKeyMapTestBase {
 	}
 
 	private static GeneralTwoKeyMap<String, String, String> copy(
-			GeneralTwoKeyMap<String, String, String> map) {
-		return new GeneralTwoKeyMap<>(map, new HashMap<>(), Suppliers.ofHashMap());
+			GeneralTwoKeyMap<String, String, String> map
+	) {
+		return new GeneralTwoKeyMap<>(HashMap.class, map);
 	}
 }

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralTwoKeyMultiMapTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/GeneralTwoKeyMultiMapTest.java
@@ -19,12 +19,12 @@
 
 package org.didelphis.structures.maps;
 
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.interfaces.TwoKeyMultiMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -32,7 +32,8 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-class GeneralTwoKeyMultiMapTest extends TwoKeyMapTestBase {
+class GeneralTwoKeyMultiMapTest
+		extends TwoKeyMapTestBase<String, String, Collection<String>> {
 
 	private TwoKeyMultiMap<String, String, String> map;
 	private TwoKeyMultiMap<String, String, String> map1;
@@ -52,8 +53,8 @@ class GeneralTwoKeyMultiMapTest extends TwoKeyMapTestBase {
 		map.add("a", "c", "v1");
 		map.add("a", "c", "v2");
 
-		map1 = new GeneralTwoKeyMultiMap<>(map, new HashMap<>(), Suppliers.ofHashMap(), Suppliers.ofHashSet());
-		map2 = new GeneralTwoKeyMultiMap<>(map, new HashMap<>(), Suppliers.ofHashMap(), Suppliers.ofHashSet());
+		map1 = new GeneralTwoKeyMultiMap<>(HashMap.class, HashSet.class, map);
+		map2 = new GeneralTwoKeyMultiMap<>(HashMap.class, HashSet.class, map);
 		map2.add("x", "y", "z");
 	}
 

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/SymmetricalTwoKeyMapTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/SymmetricalTwoKeyMapTest.java
@@ -21,7 +21,6 @@ package org.didelphis.structures.maps;
 
 import lombok.NonNull;
 
-import org.didelphis.structures.Suppliers;
 import org.didelphis.structures.maps.interfaces.TwoKeyMap;
 import org.didelphis.structures.tuples.Couple;
 import org.didelphis.structures.tuples.Triple;
@@ -62,7 +61,7 @@ class SymmetricalTwoKeyMapTest {
 	@Test
 	void testIsEmpty() {
 		assertFalse(map.isEmpty());
-		assertTrue(new SymmetricalTwoKeyMap().isEmpty());
+		assertTrue(new SymmetricalTwoKeyMap<>().isEmpty());
 	}
 
 	@Test
@@ -171,11 +170,11 @@ class SymmetricalTwoKeyMapTest {
 			hashMap.put("X", "Y");
 
 			@SuppressWarnings("unchecked")
-			Map<String, String> map = HashMap.class.getConstructor(Map.class)
-					.newInstance(hashMap);
+			Map<String, String> map = HashMap.class.getConstructor(Map.class).newInstance(hashMap);
 
 			assertEquals("Y", map.get("X"));
 		} catch (Exception ignored) {
+
 		}
 
 		assertEquals(expected, map.keys());
@@ -212,15 +211,6 @@ class SymmetricalTwoKeyMapTest {
 		assertNotEquals(map, map1);
 	}
 
-	@NonNull
-	private static <K,V> SymmetricalTwoKeyMap<K, V> copy(
-			SymmetricalTwoKeyMap<K, V> map) {
-		return new SymmetricalTwoKeyMap<>(map,
-				new HashMap<>(),
-				Suppliers.ofHashMap()
-		);
-	}
-
 	@Test
 	void testToString() {
 		assertEquals(map.toString(), copy(map).toString());
@@ -235,5 +225,12 @@ class SymmetricalTwoKeyMapTest {
 		SymmetricalTwoKeyMap<String, Integer> map1 = copy(map);
 		map1.put("X", "Y", 333);
 		assertNotEquals(map.hashCode(), map1.hashCode());
+	}
+
+	@NonNull
+	private static <K,V> SymmetricalTwoKeyMap<K, V> copy(
+			SymmetricalTwoKeyMap<K, V> map
+	) {
+		return new SymmetricalTwoKeyMap<>(HashMap.class, map);
 	}
 }

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/SymmetricalTwoKeyMultiMapTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/SymmetricalTwoKeyMultiMapTest.java
@@ -21,12 +21,11 @@ package org.didelphis.structures.maps;
 
 import lombok.NonNull;
 
-import org.didelphis.structures.Suppliers;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -79,12 +78,7 @@ class SymmetricalTwoKeyMultiMapTest {
 	}
 
 	@NonNull
-	private static <K,V> SymmetricalTwoKeyMultiMap<K, V> copy(
-			SymmetricalTwoKeyMultiMap<K, V> map) {
-		return new SymmetricalTwoKeyMultiMap<>(map,
-				new HashMap<>(),
-				Suppliers.ofHashMap(),
-				Suppliers.ofHashSet()
-		);
+	private static <K,V> SymmetricalTwoKeyMultiMap<K, V> copy(SymmetricalTwoKeyMultiMap<K, V> map) {
+		return new SymmetricalTwoKeyMultiMap<>(HashMap.class, HashSet.class, map);
 	}
 }

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/TwoKeyMapTestBase.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/maps/TwoKeyMapTestBase.java
@@ -24,28 +24,25 @@ import org.didelphis.structures.maps.interfaces.TwoKeyMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 
+class TwoKeyMapTestBase<T,U,V> {
 
-public abstract class TwoKeyMapTestBase {
-
-	protected TwoKeyMapTestBase() {}
-
-	static <T, U, V> void testGet(TwoKeyMap<T, U, V> map, T k1, U k2, V v) {
-		String string = "key (" + k1 + ',' + k2 + ") retrieved unexpected value";
-		assertEquals(v, map.get(k1, k2), string);
+	void testGet(TwoKeyMap<T, U, V> map, T k1, U k2, V v) {
+		assertEquals(v, map.get(k1, k2), () ->
+				"key (" + k1 + ", " + k2 + ") retrieved unexpected value");
 	}
 
-	static <T, U, V> void testNullGet(TwoKeyMap<T, U, V> map, T k1, U k2) {
-		String string = "key (" + k1 + ',' + k2 + ") should not exist";
-		assertNull(map.get(k1, k2), string);
+	void testNullGet(TwoKeyMap<T, U, V> map, T k1, U k2) {
+		assertNull(map.get(k1, k2), () ->
+				"key (" + k1 + ", " + k2 + ") should not exist");
 	}
 
-	static <T, U, V> void testContains(TwoKeyMap<T, U, V> map, T k1, U k2) {
-		String string = "key (" + k1 + ',' + k2 + ") should be found in maps";
-		assertTrue(map.contains(k1, k2),string);
+	void testContains(TwoKeyMap<T, U, V> map, T k1, U k2) {
+		assertTrue(map.contains(k1, k2), () ->
+				"key (" + k1 + ", " + k2 + ") should be found in maps");
 	}
 
-	static <T, U, V> void testNotContains(TwoKeyMap<T, U, V> map, T k1, U k2) {
-		String string = "key (" + k1 + ',' + k2 + ") should *not* be found in maps";
-		assertFalse(map.contains(k1, k2),string);
+	void testNotContains(TwoKeyMap<T, U, V> map, T k1, U k2) {
+		assertFalse(map.contains(k1, k2), () ->
+				"key (" + k1 + ", " + k2 + ") should *not* be found in maps");
 	}
 }

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/tables/RectangularTableTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/tables/RectangularTableTest.java
@@ -421,16 +421,6 @@ class RectangularTableTest {
 	}
 
 	@Test
-	void getDelegate() {
-		assertEquals(asList(
-				"0", "1", "2", "3", "4", "5",
-				"6", "7", "8", "9", "A", "B"
-				),
-				table.getDelegate()
-		);
-	}
-
-	@Test
 	void testColumnIterator() {
 		Iterator<Collection<String>> iterator = table.columnIterator();
 		List<Collection<String>> received = new ArrayList<>();

--- a/didelphis-common-structures/src/test/java/org/didelphis/structures/tables/SymmetricTableTest.java
+++ b/didelphis-common-structures/src/test/java/org/didelphis/structures/tables/SymmetricTableTest.java
@@ -214,7 +214,7 @@ class SymmetricTableTest {
 
 	@Test
 	void clear() {
-		assertTrue(table.clear());
+		table.clear();
 		assertTrue(table.isEmpty());
 	}
 
@@ -278,7 +278,6 @@ class SymmetricTableTest {
 	void shrink_4_4() {
 		table.shrink(4, 4);
 		assertTrue(table.isEmpty());
-		assertFalse(table.clear());
 	}
 
 	@Test


### PR DESCRIPTION
parameters instead of taking delegates suppliers directly. This is done to
avoid exposing the internals of the implementations.